### PR TITLE
chore: add manual release workflow

### DIFF
--- a/.github/workflows/manual-release.yml
+++ b/.github/workflows/manual-release.yml
@@ -1,0 +1,81 @@
+name: Manual Release
+
+permissions:
+  contents: write
+
+on:
+  workflow_dispatch:
+    inputs:
+      release_type:
+        description: Version part to increment
+        type: choice
+        required: true
+        default: patch
+        options:
+          - patch
+          - minor
+          - major
+
+jobs:
+  release:
+    if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Fetch tags
+        run: git fetch --tags
+
+      - name: Get latest tag
+        id: get_tag
+        run: |
+          last_tag=$(git describe --tags --abbrev=0 2>/dev/null || echo "0.0.0")
+          echo "last_tag=$last_tag" >> "$GITHUB_OUTPUT"
+
+      - name: Compute next version
+        id: bump
+        run: |
+          last_tag="${{ steps.get_tag.outputs.last_tag }}"
+          release_type="${{ github.event.inputs.release_type }}"
+          IFS='.' read -r major minor patch <<<"$last_tag"
+          case "$release_type" in
+            major)
+              major=$((major+1)); minor=0; patch=0;;
+            minor)
+              minor=$((minor+1)); patch=0;;
+            *)
+              patch=$((patch+1));;
+          esac
+          new_tag="$major.$minor.$patch"
+          echo "new_tag=$new_tag" >> "$GITHUB_OUTPUT"
+
+      - name: Create tag
+        env:
+          NEW_TAG: ${{ steps.bump.outputs.new_tag }}
+        run: |
+          git config user.name "${{ github.actor }}"
+          git config user.email "${{ github.actor }}@users.noreply.github.com"
+          git tag "$NEW_TAG"
+          git push origin "$NEW_TAG"
+
+      - name: Package and upload
+        uses: BigWigsMods/packager@v2
+        with:
+          args: -p 1324861
+        env:
+          CF_API_KEY: ${{ secrets.CF_API_KEY }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REF: refs/tags/${{ steps.bump.outputs.new_tag }}
+          GITHUB_REF_NAME: ${{ steps.bump.outputs.new_tag }}
+
+      - name: Create GitHub release
+        uses: softprops/action-gh-release@v1
+        with:
+          tag_name: ${{ steps.bump.outputs.new_tag }}
+          name: ${{ steps.bump.outputs.new_tag }}
+          files: .release/*.zip
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- add manual release workflow for tagging, packaging, and releasing addon

## Testing
- `npm test` *(fails: ENOENT no such file or directory, open 'package.json')*

------
https://chatgpt.com/codex/tasks/task_e_6899311ffb288333989d39c36aae022f